### PR TITLE
Aligning usage model with IntelCaffe

### DIFF
--- a/simple_net.cpp
+++ b/simple_net.cpp
@@ -73,7 +73,7 @@ void simple_net(int times = 100) {
                                      memory::format::any);
 
     /* create a convolution */
-    auto conv1_desc = convolution_forward::desc(prop_kind::forward,
+    auto conv1_desc = convolution_forward::desc(prop_kind::forward_inference,
                                                 convolution_direct, conv1_src_md, conv1_weights_md, conv1_bias_md,
                                                 conv1_dst_md, conv1_strides, conv1_padding, conv1_padding,
                                                 padding_kind::zero);
@@ -81,9 +81,10 @@ void simple_net(int times = 100) {
             convolution_forward::primitive_desc(conv1_desc, cpu_engine);
 
     std::vector<primitive> net;
+	std::vector<primitive> net_weights;
 
-    /* create reorders between user and data if it is needed and
-     *  add it to net before convolution */
+    /* create reorders for data and weights if layout requested by convolution is different
+     *  from NCHW/OIHW */
     auto conv1_src_memory = conv1_user_src_memory;
     if (memory::primitive_desc(conv1_prim_desc.src_primitive_desc()) !=
         conv1_user_src_memory.get_primitive_desc()) {
@@ -95,7 +96,7 @@ void simple_net(int times = 100) {
     if (memory::primitive_desc(conv1_prim_desc.weights_primitive_desc()) !=
         conv1_user_weights_memory.get_primitive_desc()) {
       conv1_weights_memory = memory(conv1_prim_desc.weights_primitive_desc());
-      net.push_back(reorder(conv1_user_weights_memory, conv1_weights_memory));
+      net_weights.push_back(reorder(conv1_user_weights_memory, conv1_weights_memory));
     }
 
     auto conv1_dst_memory = memory(conv1_prim_desc.dst_primitive_desc());
@@ -109,17 +110,15 @@ void simple_net(int times = 100) {
      */
     const double negative1_slope = 1.0;
 
-    auto relu1_dst_memory = memory(conv1_prim_desc.dst_primitive_desc());
-
     /* create relu primitive and add it to net */
-    auto relu1_desc = eltwise_forward::desc(prop_kind::forward,
+    auto relu1_desc = eltwise_forward::desc(prop_kind::forward_inference,
                                             algorithm::eltwise_relu,
-                                            conv1_prim_desc.dst_primitive_desc().desc(), negative1_slope);
+                                            conv1_dst_memory.get_primitive_desc().desc(), negative1_slope);
     auto relu1_prim_desc = eltwise_forward::primitive_desc(relu1_desc,
                                                            cpu_engine);
 
     net.push_back(eltwise_forward(relu1_prim_desc, conv1_dst_memory,
-                                  relu1_dst_memory));
+                                  conv1_dst_memory));
 
     /* AlexNet: lrn1
      * {batch, 96, 55, 55} -> {batch, 96, 55, 55}
@@ -132,19 +131,14 @@ void simple_net(int times = 100) {
     const double beta1 = 0.75;
     const double k1 = 1.0;
 
-    auto lrn1_dst_memory = memory(relu1_dst_memory.get_primitive_desc());
-
     /* create lrn primitive and add it to net */
-    auto lrn1_desc = lrn_forward::desc(prop_kind::forward, lrn_across_channels,
-                                       conv1_prim_desc.dst_primitive_desc().desc(), local1_size,
+    auto lrn1_desc = lrn_forward::desc(prop_kind::forward_inference, lrn_across_channels,
+                                       conv1_dst_memory.get_primitive_desc().desc(), local1_size,
                                        alpha1, beta1, k1);
     auto lrn1_prim_desc = lrn_forward::primitive_desc(lrn1_desc, cpu_engine);
+    auto lrn1_dst_memory = memory(lrn1_prim_desc.dst_primitive_desc());
 
-    /* create lrn scratch memory from lrn primitive descriptor */
-    auto lrn1_scratch_memory = memory(lrn1_prim_desc.workspace_primitive_desc());
-
-    net.push_back(lrn_forward(lrn1_prim_desc, relu1_dst_memory,
-                              lrn1_scratch_memory, lrn1_dst_memory));
+    net.push_back(lrn_forward(lrn1_prim_desc, conv1_dst_memory, lrn1_dst_memory));
 
     /* AlexNet: pool1
      * {batch, 96, 55, 55} -> {batch, 96, 27, 27}
@@ -157,32 +151,24 @@ void simple_net(int times = 100) {
     memory::dims pool1_strides = {2, 2};
     auto pool_padding = {0, 0};
 
-    std::vector<float> pool1_dst(std::accumulate(pool1_dst_tz.begin(),
-                                                 pool1_dst_tz.end(), 1, std::multiplies<uint32_t>()));
-
-    auto pool1_dst_memory = memory({{{pool1_dst_tz}, memory::data_type::f32,
-                                     memory::format::nchw}, cpu_engine}, pool1_dst.data());
-
     auto pool1_dst_md = memory::desc({pool1_dst_tz}, memory::data_type::f32,
                                      memory::format::any);
 
     /* create a pooling */
-    auto pool1_desc = pooling_forward::desc(prop_kind::forward, pooling_max,
+    auto pool1_desc = pooling_forward::desc(prop_kind::forward_inference, pooling_max,
                                             lrn1_dst_memory.get_primitive_desc().desc(), pool1_dst_md, pool1_strides,
                                             pool1_kernel, pool_padding, pool_padding, padding_kind::zero);
-    auto pool1_pd = pooling_forward::primitive_desc(pool1_desc, cpu_engine);
-
-    /* create pooling indices memory from pooling primitive descriptor */
-    auto pool1_indices_memory = memory(pool1_pd.workspace_primitive_desc());
-
+	auto pool1_pd = pooling_forward::primitive_desc(pool1_desc, cpu_engine);
+    auto pool1_dst_memory = memory(pool1_pd.dst_primitive_desc());
+	
     /* create pooling primitive an add it to net */
-    net.push_back(pooling_forward(pool1_pd, lrn1_dst_memory, pool1_dst_memory,
-                                  pool1_indices_memory));
+    net.push_back(pooling_forward(pool1_pd, lrn1_dst_memory, pool1_dst_memory));
 
     /* AlexNet: conv2
     * {batch, 96, 27, 27} (x) {2, 128, 48, 5, 5} -> {batch, 256, 27, 27}
     * strides: {1, 1}
     */
+    memory::dims conv2_src_tz = {batch, 96, 27, 27};
     memory::dims conv2_weights_tz = {2, 128, 48, 5, 5};
     memory::dims conv2_bias_tz = {256};
     memory::dims conv2_dst_tz = {batch, 256, 27, 27};
@@ -203,6 +189,8 @@ void simple_net(int times = 100) {
                                          conv2_bias.data());
 
     /* create memory descriptors for convolution data w/ no specified format */
+    auto conv2_src_md = memory::desc({conv2_src_tz}, memory::data_type::f32,
+                                      memory::format::any);
     auto conv2_bias_md = memory::desc({conv2_bias_tz}, memory::data_type::f32,
                                       memory::format::any);
     auto conv2_weights_md = memory::desc({conv2_weights_tz},
@@ -211,25 +199,32 @@ void simple_net(int times = 100) {
                                      memory::format::any);
 
     /* create a convolution */
-    auto conv2_desc = convolution_forward::desc(prop_kind::forward,
-                                                convolution_direct, pool1_dst_memory.get_primitive_desc().desc(),
+    auto conv2_desc = convolution_forward::desc(prop_kind::forward_inference,
+                                                convolution_direct, conv2_src_md,
                                                 conv2_weights_md, conv2_bias_md,
                                                 conv2_dst_md, conv2_strides, conv2_padding, conv2_padding,
                                                 padding_kind::zero);
     auto conv2_prim_desc =
             convolution_forward::primitive_desc(conv2_desc, cpu_engine);
 
+    auto conv2_src_memory = pool1_dst_memory;
+    if (memory::primitive_desc(conv2_prim_desc.src_primitive_desc()) !=
+        conv2_src_memory.get_primitive_desc()) {
+      conv2_src_memory = memory(conv2_prim_desc.src_primitive_desc());
+      net.push_back(reorder(pool1_dst_memory, conv2_src_memory));
+    }
+
     auto conv2_weights_memory = conv2_user_weights_memory;
     if (memory::primitive_desc(conv2_prim_desc.weights_primitive_desc()) !=
         conv2_user_weights_memory.get_primitive_desc()) {
       conv2_weights_memory = memory(conv2_prim_desc.weights_primitive_desc());
-      net.push_back(reorder(conv2_user_weights_memory, conv2_weights_memory));
+      net_weights.push_back(reorder(conv2_user_weights_memory, conv2_weights_memory));
     }
 
     auto conv2_dst_memory = memory(conv2_prim_desc.dst_primitive_desc());
 
     /* create convolution primitive and add it to net */
-    net.push_back(convolution_forward(conv2_prim_desc, pool1_dst_memory,
+    net.push_back(convolution_forward(conv2_prim_desc, conv2_src_memory,
                                       conv2_weights_memory, conv2_user_bias_memory, conv2_dst_memory));
 
     /* AlexNet: relu2
@@ -237,17 +232,15 @@ void simple_net(int times = 100) {
     */
     const double negative2_slope = 1.0;
 
-    auto relu2_dst_memory = memory(conv2_prim_desc.dst_primitive_desc());
-
     /* create relu primitive and add it to net */
-    auto relu2_desc = eltwise_forward::desc(prop_kind::forward,
+    auto relu2_desc = eltwise_forward::desc(prop_kind::forward_inference,
                                             algorithm::eltwise_relu,
-                                            conv2_prim_desc.dst_primitive_desc().desc(), negative2_slope);
+                                            conv2_dst_memory.get_primitive_desc().desc(), negative2_slope);
     auto relu2_prim_desc = eltwise_forward::primitive_desc(relu2_desc,
                                                            cpu_engine);
 
     net.push_back(eltwise_forward(relu2_prim_desc, conv2_dst_memory,
-                                  relu2_dst_memory));
+                                  conv2_dst_memory));
 
     /* AlexNet: lrn2
      * {batch, 256, 27, 27} -> {batch, 256, 27, 27}
@@ -260,19 +253,16 @@ void simple_net(int times = 100) {
     const double beta2 = 0.75;
     const double k2 = 1.0;
 
-    auto lrn2_dst_memory = memory(relu2_dst_memory.get_primitive_desc());
-
     /* create lrn primitive and add it to net */
-    auto lrn2_desc = lrn_forward::desc(prop_kind::forward, lrn_across_channels,
+    auto lrn2_desc = lrn_forward::desc(prop_kind::forward_inference, lrn_across_channels,
                                        conv2_prim_desc.dst_primitive_desc().desc(), local2_size,
                                        alpha2, beta2, k2);
     auto lrn2_prim_desc = lrn_forward::primitive_desc(lrn2_desc, cpu_engine);
+    auto lrn2_dst_memory = memory(lrn2_prim_desc.dst_primitive_desc());
 
-    /* create lrn scratch memory from lrn primitive descriptor */
-    auto lrn2_scratch_memory = memory(lrn2_prim_desc.workspace_primitive_desc());
 
-    net.push_back(lrn_forward(lrn2_prim_desc, relu2_dst_memory,
-                              lrn2_scratch_memory, lrn2_dst_memory));
+    net.push_back(lrn_forward(lrn2_prim_desc, conv2_dst_memory,
+                              lrn2_dst_memory));
 
 
     /* AlexNet: pool2
@@ -286,35 +276,26 @@ void simple_net(int times = 100) {
     memory::dims pool2_strides = {2, 2};
     auto pool2_padding = {0, 0};
 
-    std::vector<float> pool2_dst(std::accumulate(pool2_dst_tz.begin(),
-                                                 pool2_dst_tz.end(), 1, std::multiplies<uint32_t>()));
-
-    auto pool2_dst_memory = memory({{{pool2_dst_tz}, memory::data_type::f32,
-                                     memory::format::nchw}, cpu_engine}, pool2_dst.data());
-
     auto pool2_dst_md = memory::desc({pool2_dst_tz}, memory::data_type::f32,
                                      memory::format::any);
 
     /* create a pooling */
-    auto pool2_desc = pooling_forward::desc(prop_kind::forward, pooling_max,
+    auto pool2_desc = pooling_forward::desc(prop_kind::forward_inference, pooling_max,
                                             lrn2_dst_memory.get_primitive_desc().desc(), pool2_dst_md, pool2_strides,
                                             pool2_kernel, pool2_padding, pool2_padding, padding_kind::zero);
     auto pool2_pd = pooling_forward::primitive_desc(pool2_desc, cpu_engine);
 
-
-
-    /* create pooling indices memory from pooling primitive descriptor */
-    auto pool2_indices_memory = memory(pool2_pd.workspace_primitive_desc());
+    auto pool2_dst_memory = memory(pool2_pd.dst_primitive_desc());
 
     /* create pooling primitive an add it to net */
-    net.push_back(pooling_forward(pool2_pd, lrn2_dst_memory, pool2_dst_memory,
-                                  pool2_indices_memory));
+    net.push_back(pooling_forward(pool2_pd, lrn2_dst_memory, pool2_dst_memory));
 
     // -------
     /* AlexNet: conv3
     * {batch, 256, 13, 13} (x)  {384, 256, 3, 3}; -> {batch, 384, 13, 13};
     * strides: {1, 1}
     */
+    memory::dims conv3_src_tz = {batch, 256, 13, 13};
     memory::dims conv3_weights_tz = {384, 256, 3, 3};
     memory::dims conv3_bias_tz = {384};
     memory::dims conv3_dst_tz = {batch, 384, 13, 13};
@@ -335,6 +316,8 @@ void simple_net(int times = 100) {
                                          conv3_bias.data());
 
     /* create memory descriptors for convolution data w/ no specified format */
+    auto conv3_src_md = memory::desc({conv3_src_tz}, memory::data_type::f32,
+                                      memory::format::any);
     auto conv3_bias_md = memory::desc({conv3_bias_tz}, memory::data_type::f32,
                                       memory::format::any);
     auto conv3_weights_md = memory::desc({conv3_weights_tz},
@@ -343,25 +326,32 @@ void simple_net(int times = 100) {
                                      memory::format::any);
 
     /* create a convolution */
-    auto conv3_desc = convolution_forward::desc(prop_kind::forward,
-                                                convolution_direct, pool2_dst_memory.get_primitive_desc().desc(),
+    auto conv3_desc = convolution_forward::desc(prop_kind::forward_inference,
+                                                convolution_direct, conv3_src_md,
                                                 conv3_weights_md, conv3_bias_md,
                                                 conv3_dst_md, conv3_strides, conv3_padding, conv3_padding,
                                                 padding_kind::zero);
     auto conv3_prim_desc =
             convolution_forward::primitive_desc(conv3_desc, cpu_engine);
 
+    auto conv3_src_memory = pool2_dst_memory;
+    if (memory::primitive_desc(conv3_prim_desc.src_primitive_desc()) !=
+        conv3_src_memory.get_primitive_desc()) {
+      conv3_src_memory = memory(conv3_prim_desc.src_primitive_desc());
+      net.push_back(reorder(pool2_dst_memory, conv3_src_memory));
+    }
+
     auto conv3_weights_memory = conv3_user_weights_memory;
     if (memory::primitive_desc(conv3_prim_desc.weights_primitive_desc()) !=
         conv3_user_weights_memory.get_primitive_desc()) {
       conv3_weights_memory = memory(conv3_prim_desc.weights_primitive_desc());
-      net.push_back(reorder(conv3_user_weights_memory, conv3_weights_memory));
+      net_weights.push_back(reorder(conv3_user_weights_memory, conv3_weights_memory));
     }
 
     auto conv3_dst_memory = memory(conv3_prim_desc.dst_primitive_desc());
 
     /* create convolution primitive and add it to net */
-    net.push_back(convolution_forward(conv3_prim_desc, pool2_dst_memory,
+    net.push_back(convolution_forward(conv3_prim_desc, conv3_src_memory,
                                       conv3_weights_memory, conv3_user_bias_memory, conv3_dst_memory));
 
     /* AlexNet: relu3
@@ -369,22 +359,20 @@ void simple_net(int times = 100) {
     */
     const double negative3_slope = 1.0;
 
-    auto relu3_dst_memory = memory(conv3_prim_desc.dst_primitive_desc());
-
     /* create relu primitive and add it to net */
-    auto relu3_desc = eltwise_forward::desc(prop_kind::forward,
+    auto relu3_desc = eltwise_forward::desc(prop_kind::forward_inference,
                                             algorithm::eltwise_relu,
-                                            conv3_prim_desc.dst_primitive_desc().desc(), negative3_slope);
+                                            conv3_dst_memory.get_primitive_desc().desc(), negative3_slope);
     auto relu3_prim_desc = eltwise_forward::primitive_desc(relu3_desc,
                                                            cpu_engine);
 
-    net.push_back(eltwise_forward(relu3_prim_desc, conv3_dst_memory,
-                                  relu3_dst_memory));
+    net.push_back(eltwise_forward(relu3_prim_desc, conv3_dst_memory, conv3_dst_memory));
 
     /* AlexNet: conv4
     * {batch, 384, 13, 13} (x)  {2, 192, 192, 3, 3}; -> {batch, 384, 13, 13};
     * strides: {1, 1}
     */
+    memory::dims conv4_src_tz = {batch, 384, 13, 13};
     memory::dims conv4_weights_tz = {2, 192, 192, 3, 3};
     memory::dims conv4_bias_tz = {384};
     memory::dims conv4_dst_tz = {batch, 384, 13, 13};
@@ -405,6 +393,8 @@ void simple_net(int times = 100) {
                                          conv4_bias.data());
 
     /* create memory descriptors for convolution data w/ no specified format */
+    auto conv4_src_md = memory::desc({conv4_src_tz}, memory::data_type::f32,
+                                      memory::format::any);
     auto conv4_bias_md = memory::desc({conv4_bias_tz}, memory::data_type::f32,
                                       memory::format::any);
     auto conv4_weights_md = memory::desc({conv4_weights_tz},
@@ -413,25 +403,32 @@ void simple_net(int times = 100) {
                                      memory::format::any);
 
     /* create a convolution */
-    auto conv4_desc = convolution_forward::desc(prop_kind::forward,
-                                                convolution_direct, relu3_dst_memory.get_primitive_desc().desc(),
+    auto conv4_desc = convolution_forward::desc(prop_kind::forward_inference,
+                                                convolution_direct, conv4_src_md,
                                                 conv4_weights_md, conv4_bias_md,
                                                 conv4_dst_md, conv4_strides, conv4_padding, conv4_padding,
                                                 padding_kind::zero);
     auto conv4_prim_desc =
             convolution_forward::primitive_desc(conv4_desc, cpu_engine);
 
+    auto conv4_src_memory = conv3_dst_memory;
+    if (memory::primitive_desc(conv4_prim_desc.src_primitive_desc()) !=
+        conv4_src_memory.get_primitive_desc()) {
+      conv4_src_memory = memory(conv4_prim_desc.src_primitive_desc());
+      net.push_back(reorder(conv3_dst_memory, conv4_src_memory));
+    }
+
     auto conv4_weights_memory = conv4_user_weights_memory;
     if (memory::primitive_desc(conv4_prim_desc.weights_primitive_desc()) !=
         conv4_user_weights_memory.get_primitive_desc()) {
       conv4_weights_memory = memory(conv4_prim_desc.weights_primitive_desc());
-      net.push_back(reorder(conv4_user_weights_memory, conv4_weights_memory));
+      net_weights.push_back(reorder(conv4_user_weights_memory, conv4_weights_memory));
     }
 
     auto conv4_dst_memory = memory(conv4_prim_desc.dst_primitive_desc());
 
     /* create convolution primitive and add it to net */
-    net.push_back(convolution_forward(conv4_prim_desc, relu3_dst_memory,
+    net.push_back(convolution_forward(conv4_prim_desc, conv4_src_memory,
                                       conv4_weights_memory, conv4_user_bias_memory, conv4_dst_memory));
 
     /* AlexNet: relu4
@@ -439,17 +436,15 @@ void simple_net(int times = 100) {
     */
     const double negative4_slope = 1.0;
 
-    auto relu4_dst_memory = memory(conv4_prim_desc.dst_primitive_desc());
-
     /* create relu primitive and add it to net */
-    auto relu4_desc = eltwise_forward::desc(prop_kind::forward,
+    auto relu4_desc = eltwise_forward::desc(prop_kind::forward_inference,
                                             algorithm::eltwise_relu,
-                                            conv4_prim_desc.dst_primitive_desc().desc(), negative4_slope);
+                                            conv4_dst_memory.get_primitive_desc().desc(), negative4_slope);
     auto relu4_prim_desc = eltwise_forward::primitive_desc(relu4_desc,
                                                            cpu_engine);
 
     net.push_back(eltwise_forward(relu4_prim_desc, conv4_dst_memory,
-                                  relu4_dst_memory));
+                                  conv4_dst_memory));
 
     /* AlexNet: conv5
     * {batch, 384, 13, 13} (x)  {2, 128, 192, 3, 3}; -> {batch, 256, 13, 13};
@@ -483,25 +478,32 @@ void simple_net(int times = 100) {
                                      memory::format::any);
 
     /* create a convolution */
-    auto conv5_desc = convolution_forward::desc(prop_kind::forward,
-                                                convolution_direct, relu4_dst_memory.get_primitive_desc().desc(),
+    auto conv5_desc = convolution_forward::desc(prop_kind::forward_inference,
+                                                convolution_direct, conv4_dst_memory.get_primitive_desc().desc(),
                                                 conv5_weights_md, conv5_bias_md,
                                                 conv5_dst_md, conv5_strides, conv5_padding, conv5_padding,
                                                 padding_kind::zero);
     auto conv5_prim_desc =
             convolution_forward::primitive_desc(conv5_desc, cpu_engine);
 
+    auto conv5_src_memory = conv4_dst_memory;
+    if (memory::primitive_desc(conv5_prim_desc.src_primitive_desc()) !=
+        conv5_src_memory.get_primitive_desc()) {
+      conv5_src_memory = memory(conv5_prim_desc.src_primitive_desc());
+      net.push_back(reorder(conv4_dst_memory, conv5_src_memory));
+    }
+
     auto conv5_weights_memory = conv5_user_weights_memory;
     if (memory::primitive_desc(conv5_prim_desc.weights_primitive_desc()) !=
         conv5_user_weights_memory.get_primitive_desc()) {
       conv5_weights_memory = memory(conv5_prim_desc.weights_primitive_desc());
-      net.push_back(reorder(conv5_user_weights_memory, conv5_weights_memory));
+      net_weights.push_back(reorder(conv5_user_weights_memory, conv5_weights_memory));
     }
 
     auto conv5_dst_memory = memory(conv5_prim_desc.dst_primitive_desc());
 
     /* create convolution primitive and add it to net */
-    net.push_back(convolution_forward(conv5_prim_desc, relu4_dst_memory,
+    net.push_back(convolution_forward(conv5_prim_desc, conv5_src_memory,
                                       conv5_weights_memory, conv5_user_bias_memory, conv5_dst_memory));
 
     /* AlexNet: relu5
@@ -509,17 +511,15 @@ void simple_net(int times = 100) {
     */
     const double negative5_slope = 1.0;
 
-    auto relu5_dst_memory = memory(conv5_prim_desc.dst_primitive_desc());
-
     /* create relu primitive and add it to net */
-    auto relu5_desc = eltwise_forward::desc(prop_kind::forward,
+    auto relu5_desc = eltwise_forward::desc(prop_kind::forward_inference,
                                             algorithm::eltwise_relu,
-                                            conv5_prim_desc.dst_primitive_desc().desc(), negative5_slope);
+                                            conv5_dst_memory.get_primitive_desc().desc(), negative5_slope);
     auto relu5_prim_desc = eltwise_forward::primitive_desc(relu5_desc,
                                                            cpu_engine);
 
     net.push_back(eltwise_forward(relu5_prim_desc, conv5_dst_memory,
-                                  relu5_dst_memory));
+                                  conv5_dst_memory));
 
     /* AlexNet: pool5
     * {batch, 256, 13, 13} -> {batch, 256, 6, 6}
@@ -535,30 +535,26 @@ void simple_net(int times = 100) {
     std::vector<float> pool5_dst(std::accumulate(pool5_dst_tz.begin(),
                                                  pool5_dst_tz.end(), 1, std::multiplies<uint32_t>()));
 
-    auto pool5_dst_memory = memory({{{pool5_dst_tz}, memory::data_type::f32,
-                                     memory::format::nchw}, cpu_engine}, pool5_dst.data());
-
     auto pool5_dst_md = memory::desc({pool5_dst_tz}, memory::data_type::f32,
                                      memory::format::any);
 
     /* create a pooling */
-    auto pool5_desc = pooling_forward::desc(prop_kind::forward, pooling_max,
-                                            relu5_dst_memory.get_primitive_desc().desc(), pool5_dst_md, pool5_strides,
+    auto pool5_desc = pooling_forward::desc(prop_kind::forward_inference, pooling_max,
+                                            conv5_dst_memory.get_primitive_desc().desc(), pool5_dst_md, pool5_strides,
                                             pool5_kernel, pool5_padding, pool5_padding, padding_kind::zero);
     auto pool5_pd = pooling_forward::primitive_desc(pool5_desc, cpu_engine);
 
+	auto pool5_dst_memory = memory(pool5_pd.dst_primitive_desc());
 
-    /* create pooling indices memory from pooling primitive descriptor */
-    auto pool5_indices_memory = memory(pool5_pd.workspace_primitive_desc());
 
     /* create pooling primitive an add it to net */
-    net.push_back(pooling_forward(pool5_pd, relu5_dst_memory, pool5_dst_memory,
-                                  pool5_indices_memory));
+    net.push_back(pooling_forward(pool5_pd, conv5_dst_memory, pool5_dst_memory));
 
 
     /**
      * fc6 inner product {batch, 256, 6, 6} (x) {4096, 256, 6, 6}-> {batch, 4096}
      */
+    memory::dims fc6_src_tz = {batch, 256, 6, 6};
     memory::dims fc6_weights_tz = {4096, 256, 6, 6};
     memory::dims fc6_bias_tz = {4096};
     memory::dims fc6_dst_tz = {batch, 4096};
@@ -578,34 +574,42 @@ void simple_net(int times = 100) {
                                        fc6_bias.data());
 
     /* create memory descriptors for convolution data w/ no specified format */
+    auto fc6_src_md = memory::desc({fc6_src_tz}, memory::data_type::f32, memory::format::any);
     auto fc6_bias_md = memory::desc({fc6_bias_tz}, memory::data_type::f32, memory::format::any);
     auto fc6_weights_md = memory::desc({fc6_weights_tz}, memory::data_type::f32, memory::format::any);
     auto fc6_dst_md = memory::desc({fc6_dst_tz}, memory::data_type::f32, memory::format::any);
 
     /* create a inner_product */
-    auto fc6_desc = inner_product_forward::desc(prop_kind::forward, pool5_dst_memory.get_primitive_desc().desc(),
+    auto fc6_desc = inner_product_forward::desc(prop_kind::forward_inference, fc6_src_md,
                                                 fc6_weights_md, fc6_bias_md,
                                                 fc6_dst_md);
     auto fc6_prim_desc =
             inner_product_forward::primitive_desc(fc6_desc, cpu_engine);
 
+    auto fc6_src_memory = pool5_dst_memory;
+    if (memory::primitive_desc(fc6_prim_desc.src_primitive_desc()) !=
+        fc6_src_memory.get_primitive_desc()) {
+      fc6_src_memory = memory(fc6_prim_desc.src_primitive_desc());
+      net.push_back(reorder(pool5_dst_memory, fc6_src_memory));
+    }
+
     auto fc6_weights_memory = fc6_user_weights_memory;
     if (memory::primitive_desc(fc6_prim_desc.weights_primitive_desc()) !=
         fc6_user_weights_memory.get_primitive_desc()) {
       fc6_weights_memory = memory(fc6_prim_desc.weights_primitive_desc());
-      net.push_back(reorder(fc6_user_weights_memory, fc6_weights_memory));
+      net_weights.push_back(reorder(fc6_user_weights_memory, fc6_weights_memory));
     }
 
     auto fc6_dst_memory = memory(fc6_prim_desc.dst_primitive_desc());
 
     /* create convolution primitive and add it to net */
-    net.push_back(inner_product_forward(fc6_prim_desc, pool5_dst_memory,
+    net.push_back(inner_product_forward(fc6_prim_desc, fc6_src_memory,
                                         fc6_weights_memory, fc6_user_bias_memory, fc6_dst_memory));
 
     /**
      * fc7 inner product {batch, 4096} (x) {4096, 4096}-> {batch, 4096}
      */
-    memory::dims fc7_weights_tz = {4096, 4096};
+	memory::dims fc7_weights_tz = {4096, 4096};
     memory::dims fc7_bias_tz = {4096};
     memory::dims fc7_dst_tz = {batch, 4096};
 
@@ -629,7 +633,7 @@ void simple_net(int times = 100) {
     auto fc7_dst_md = memory::desc({fc7_dst_tz}, memory::data_type::f32, memory::format::any);
 
     /* create a inner_product */
-    auto fc7_desc = inner_product_forward::desc(prop_kind::forward, fc6_dst_memory.get_primitive_desc().desc(),
+    auto fc7_desc = inner_product_forward::desc(prop_kind::forward_inference, fc6_dst_memory.get_primitive_desc().desc(),
                                                 fc7_weights_md, fc7_bias_md,
                                                 fc7_dst_md);
     auto fc7_prim_desc = inner_product_forward::primitive_desc(fc7_desc, cpu_engine);
@@ -677,7 +681,7 @@ void simple_net(int times = 100) {
     auto fc8_dst_md = memory::desc({fc8_dst_tz}, memory::data_type::f32, memory::format::any);
 
     /* create a inner_product */
-    auto fc8_desc = inner_product_forward::desc(prop_kind::forward, fc7_dst_memory.get_primitive_desc().desc(),
+    auto fc8_desc = inner_product_forward::desc(prop_kind::forward_inference, fc7_dst_memory.get_primitive_desc().desc(),
                                                 fc8_weights_md, fc8_bias_md,
                                                 fc8_dst_md);
     auto fc8_prim_desc = inner_product_forward::primitive_desc(fc8_desc, cpu_engine);
@@ -686,7 +690,7 @@ void simple_net(int times = 100) {
     if (memory::primitive_desc(fc8_prim_desc.weights_primitive_desc()) !=
         fc8_user_weights_memory.get_primitive_desc()) {
       fc8_weights_memory = memory(fc8_prim_desc.weights_primitive_desc());
-      net.push_back(reorder(fc8_user_weights_memory, fc8_weights_memory));
+      net_weights.push_back(reorder(fc8_user_weights_memory, fc8_weights_memory));
     }
 
     auto fc8_dst_memory = memory(fc8_prim_desc.dst_primitive_desc());
@@ -701,10 +705,10 @@ void simple_net(int times = 100) {
       net.push_back(reorder(fc8_dst_memory, net_dst_memory));
     }
 
+    stream(stream::kind::eager).submit(net_weights).wait();
     for (int j = 0; j < times; ++j) {
       long begin = chrono::duration_cast<chrono::milliseconds>(chrono::steady_clock::now().time_since_epoch()).count();
       stream(stream::kind::eager).submit(net).wait();
-//      stream(stream::kind::lazy).submit(net).wait();
       long end = chrono::duration_cast<chrono::milliseconds>(chrono::steady_clock::now().time_since_epoch()).count();
       printf("Times %d use time %ld\n", j, (end - begin));
     }


### PR DESCRIPTION
I made a few changes in the code to get better performance:
1. Added source conversions for convolutions and the first inner product. While conversions between convolutions will not happen in this particular code it's not safe to assume that these are not required. Conversion for inner product is required, as preferred src layout for inner product is different from what conv5 produces.
2. ReLU changed to in-place
3. Dropped workspaces as these are not required for inference
4. Changed dst layout for pooling to `any`